### PR TITLE
Sdss 349 earth news importer candidate

### DIFF
--- a/config/install/migrate_plus.migration.earth_news_importer_2013.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2013.yml
@@ -1,0 +1,276 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2013
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2013'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2013'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+  su_sdss_import/url:
+    plugin: concat
+    source:
+      constants/base_url
+      alias
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2013.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2013.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2013.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2013.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -225,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -250,27 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
-  su_sdss_import/url:
+  su_sdss_import_source:
     plugin: concat
     source:
-      constants/base_url
-      alias
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2013.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2013.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2013'
+    - 'https://earth.stanford.edu/export-news?year=2013'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2014.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2014.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2014.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2014.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2014'
+    - 'https://earth.stanford.edu/export-news?year=2014'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2014.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2014.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2014
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2014'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2014'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2014.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2014.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2015.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2015.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2015.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2015.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2015.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2015.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2015
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2015'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2015'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2015.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2015.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2015'
+    - 'https://earth.stanford.edu/export-news?year=2015'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2016.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2016.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2016.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2016.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2016.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2016.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2016'
+    - 'https://earth.stanford.edu/export-news?year=2016'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2016.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2016.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2016
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2016'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2016'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2017.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2017.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2017'
+    - 'https://earth.stanford.edu/export-news?year=2017'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2017.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2017.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2017.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2017.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2017
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2017'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2017'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2017.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2017.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2018.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2018.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2018
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2018'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2018'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2018.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2018.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2018.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2018.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2018.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2018.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2018'
+    - 'https://earth.stanford.edu/export-news?year=2018'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2019.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2019.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2019.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2019.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2019.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2019.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2019'
+    - 'https://earth.stanford.edu/export-news?year=2019'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2019.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2019.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2019
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2019'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2019'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2020.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2020.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2020.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2020.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2020.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2020.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2020
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2020'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2020'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2020.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2020.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2020'
+    - 'https://earth.stanford.edu/export-news?year=2020'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2021.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2021.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2021.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2021.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2021.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2021.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2021'
+    - 'https://earth.stanford.edu/export-news?year=2021'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2021.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2021.yml
@@ -1,0 +1,270 @@
+langcode: en
+status: true
+dependencies: {  }
+id: earth_news_importer_2021
+class: null
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags: {  }
+migration_group: earth_news_importer
+label: 'earth news importer 2021'
+source:
+  track_changes: true
+  plugin: url
+  data_fetcher_plugin: http
+  request_options:
+    timeout: 60
+  urls:
+    - 'https://se3-stage.stanford.edu/export-news?year=2021'
+  data_parser_plugin: json
+  item_selector: nodes
+  fields:
+    -
+      name: id
+      label: ID
+      selector: nid
+    -
+      name: title
+      label: Title
+      selector: title
+    -
+      name: alias
+      label: Alias
+      selector: path/0/alias
+    -
+      name: earth_matters_topics
+      label: 'Earth Matters Topics'
+      selector: field_earth_matters_topic
+    -
+      name: author
+      label: Author
+      selector: field_s_news_author/0/value
+    -
+      name: news_category
+      label: 'News Category'
+      selector: field_s_news_category
+    -
+      name: news_challenge
+      label: 'News Challenge Area'
+      selector: field_s_news_challenge
+    -
+      name: news_date
+      label: 'News Date'
+      selector: field_s_news_date/0/value
+    -
+      name: departments
+      label: Department
+      selector: field_s_news_department
+    -
+      name: earth_tags
+      label: 'Earth Tags'
+      selector: field_s_news_earth_tags
+    -
+      name: feature_media
+      label: 'Feature Media'
+      selector: field_s_news_feat_media
+    -
+      name: rich_content
+      label: Rich Content
+      selector: field_s_news_rich_content
+    -
+      name: earth_teaser
+      label: 'Earth News Teaser'
+      selector: field_s_news_teaser/0
+    -
+      name: earth_summary
+      label: 'Earth News Summary'
+      selector: field_s_news_summary/0
+    -
+      name: banner_media
+      label: 'Banner Media'
+      selector: field_s_news_top_media/0/field_p_hero_banner_media
+    -
+      name: banner_media_caption
+      label: 'Banner Media Caption'
+      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+    -
+      name: news_source
+      label: 'News Source'
+      selector: field_s_news_source
+    -
+      name: embedded_media
+      label: Embedded Media
+      selector: embedded_media
+    -
+      name: field_media
+      label: Field Media
+      selector: field_media
+  ids:
+    id:
+      type: string
+  constants:
+    one: 1
+    type: stanford_news
+    stanford_html: stanford_html
+    stanford_minimal_html: stanford_minimal_html
+    image_path: 'public://media/earth_news/'
+process:
+  reset:
+    plugin: earth_news_paragraphs_delete
+    method: process
+    source: id
+  embedded_media:
+    plugin: earth_media_image
+    source: embedded_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: true
+  field_media:
+    plugin: earth_media_image
+    source: field_media
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    destination: constants/image_path
+    embed: false
+  status: constants/one
+  type: constants/type
+  title: title
+  path/alias: alias
+  su_sdss_magazine_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_matters_topics
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_magazine_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_byline: author
+  su_news_topics:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_category
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: stanford_news_topics
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_sdss_news_research_area:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: news_challenge
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_research_areas
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_publishing_date/value:
+    -
+      plugin: skip_on_empty
+      source: news_date
+      method: process
+    -
+      plugin: substr
+      start: 0
+      length: 10
+      callable: strtotime
+      source: news_date
+  su_sdss_news_organization:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: departments
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: sdss_organization
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_shared_tags:
+    -
+      plugin: skip_on_empty
+      method: process
+      source: earth_tags
+    -
+      plugin: sub_process
+      process:
+        target_id:
+          plugin: entity_generate
+          value_key: name
+          bundle_key: vid
+          bundle: su_shared_tags
+          entity_type: taxonomy_term
+          ignore_case: true
+          source: term_name
+  su_news_featured_media:
+      plugin: earth_media_field_id
+      source: feature_media
+      id_only: true
+      field_media: field_media
+  su_news_components:
+      plugin: earth_news_paragraphs
+      source: rich_content
+      skip_on_error: true
+      id_only: true
+      reuse: true
+      uid: 0
+      field_media: field_media
+      embedded_media: embedded_media
+  dek:
+    plugin: earth_teaser_or_summary
+    method: process
+    earth_teaser: earth_teaser
+    earth_summary: earth_summary
+    source: null
+  su_sdss_news_dek_long/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: dek
+    embedded_media: embedded_media
+  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_news_banner:
+    plugin: earth_media_field_id
+    source: banner_media
+    id_only: true
+    field_media: field_media
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
+  su_news_source: news_source
+destination:
+  plugin: 'entity:node'
+migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2022.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2022.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2022.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2022.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2022.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2022.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2022'
+    - 'https://earth.stanford.edu/export-news?year=2022'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2022.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2022.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://earth.stanford.edu/export-news?year=2022'
+    - 'https://se3-stage.stanford.edu/export-news?year=2022'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -105,7 +105,7 @@ source:
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
 process:
-  reset: 
+  reset:
     plugin: earth_news_paragraphs_delete
     method: process
     source: id
@@ -255,10 +255,15 @@ process:
     source: banner_media
     id_only: true
     field_media: field_media
-#  su_news_banner_media_caption: 
-#    plugin: callback
-#    callable: strip_tags
-#    source: banner_media_caption 
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
   su_news_source: news_source
 destination:
   plugin: 'entity:node'

--- a/config/install/migrate_plus.migration.earth_news_importer_2023.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2023.yml
@@ -65,7 +65,7 @@ source:
       selector: field_s_news_feat_media
     -
       name: rich_content
-      label: Rich Content
+      label: 'Rich Content'
       selector: field_s_news_rich_content
     -
       name: earth_teaser
@@ -78,22 +78,18 @@ source:
     -
       name: banner_media
       label: 'Banner Media'
-      selector: field_s_news_top_media/0/field_p_hero_banner_media
-    -
-      name: banner_media_caption
-      label: 'Banner Media Caption'
-      selector: field_s_news_top_media/0/field_p_hero_banner_photo_credit/0
+      selector: field_s_news_top_media
     -
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
     -
       name: embedded_media
-      label: Embedded Media
+      label: 'Embedded Media'
       selector: embedded_media
     -
       name: field_media
-      label: Field Media
+      label: 'Field Media'
       selector: field_media
   ids:
     id:
@@ -104,6 +100,7 @@ source:
     stanford_html: stanford_html
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
+    base_url: 'https://earth.stanford.edu'
 process:
   reset:
     plugin: earth_news_paragraphs_delete
@@ -224,19 +221,19 @@ process:
           ignore_case: true
           source: term_name
   su_news_featured_media:
-      plugin: earth_media_field_id
-      source: feature_media
-      id_only: true
-      field_media: field_media
+    plugin: earth_media_field_id
+    source: feature_media
+    id_only: true
+    field_media: field_media
   su_news_components:
-      plugin: earth_news_paragraphs
-      source: rich_content
-      skip_on_error: true
-      id_only: true
-      reuse: true
-      uid: 0
-      field_media: field_media
-      embedded_media: embedded_media
+    plugin: earth_news_paragraphs
+    source: rich_content
+    skip_on_error: true
+    id_only: true
+    reuse: true
+    uid: 0
+    field_media: field_media
+    embedded_media: embedded_media
   dek:
     plugin: earth_teaser_or_summary
     method: process
@@ -249,22 +246,21 @@ process:
     source: null
     dek: dek
     embedded_media: embedded_media
-  su_sdss_news_dek_long/format : constants/stanford_minimal_html
+  su_sdss_news_dek_long/format: constants/stanford_minimal_html
   su_news_banner:
-    plugin: earth_media_field_id
+    plugin: earth_banner_media
     source: banner_media
     id_only: true
     field_media: field_media
   su_news_banner_media_caption:
-    -
-      plugin: callback
-      callable: strip_tags
-      source: banner_media_caption
-    -
-      plugin: substr
-      start: 0
-      length: 255
+    plugin: earth_banner_media_caption
+    source: banner_media
   su_news_source: news_source
+  su_sdss_import_source:
+    plugin: concat
+    source:
+      - constants/base_url
+      - alias
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2023.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2023.yml
@@ -99,6 +99,7 @@ source:
     id:
       type: string
   constants:
+    zero: 0
     one: 1
     type: stanford_news
     stanford_html: stanford_html
@@ -128,7 +129,7 @@ process:
     uid: 0
     destination: constants/image_path
     embed: false
-  status: constants/one
+  status: constants/zero
   type: constants/type
   title: title
   path/alias: alias

--- a/config/install/migrate_plus.migration.earth_news_importer_2023.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2023.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://se3-stage.stanford.edu/export-news?year=2023'
+    - 'https://earth.stanford.edu/export-news?year=2023'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -83,6 +83,10 @@ source:
       name: news_source
       label: 'News Source'
       selector: field_s_news_source
+    -
+      name: related_people
+      label: 'Related People'
+      selector: field_news_related_people
     -
       name: embedded_media
       label: 'Embedded Media'
@@ -261,6 +265,9 @@ process:
     source:
       - constants/base_url
       - alias
+  su_sdss_person_ref:
+    plugin: earth_related_people
+    source: related_people
 destination:
   plugin: 'entity:node'
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2023.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2023.yml
@@ -15,7 +15,7 @@ source:
   request_options:
     timeout: 60
   urls:
-    - 'https://earth.stanford.edu/export-news?year=2023'
+    - 'https://se3-stage.stanford.edu/export-news?year=2023'
   data_parser_plugin: json
   item_selector: nodes
   fields:
@@ -105,7 +105,7 @@ source:
     stanford_minimal_html: stanford_minimal_html
     image_path: 'public://media/earth_news/'
 process:
-  reset: 
+  reset:
     plugin: earth_news_paragraphs_delete
     method: process
     source: id
@@ -255,10 +255,15 @@ process:
     source: banner_media
     id_only: true
     field_media: field_media
-#  su_news_banner_media_caption: 
-#    plugin: callback
-#    callable: strip_tags
-#    source: banner_media_caption 
+  su_news_banner_media_caption:
+    -
+      plugin: callback
+      callable: strip_tags
+      source: banner_media_caption
+    -
+      plugin: substr
+      start: 0
+      length: 255
   su_news_source: news_source
 destination:
   plugin: 'entity:node'

--- a/src/Plugin/migrate/process/EarthBannerMedia.php
+++ b/src/Plugin/migrate/process/EarthBannerMedia.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\earth_news_importer\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\earth_news_importer\EarthNewsImporterUtility;
+
+/**
+ * Gets the Old Earth media entity id for a banner field and replaces it with
+ * the media id for the imported image or file.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "earth_banner_media"
+ * )
+ *
+ */
+class EarthBannerMedia extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    if (!empty($value['field_p_hero_banner_media'])) {
+      $banner_media = reset($value['field_p_hero_banner_media']);
+      if (!empty($banner_media['type']) && $banner_media['type'] === 'image'
+        && !empty($banner_media['id'])) {
+        $field_media = [];
+        if (!empty($this->configuration['field_media'])) {
+          $field_media = $row->getDestinationProperty($this->configuration['field_media']);
+        }
+        $target_id = EarthNewsImporterUtility::replaceFieldMediaId($banner_media['id'], $field_media);
+        return ['target_id' => $target_id];
+      }
+      else {
+        $xyz = 1; //banner media not image?
+        return null;
+      }
+    }
+    else if (!empty($value['field_p_video_url'])) {
+      $video_value = reset($value['field_p_video_url']);
+      if (empty($video_value)) {
+        return null;
+      }
+      $mid = EarthNewsImporterUtility::lookupMediaByProperty(
+        'field_media_oembed_video.value', $video_value);
+      if (!empty($mid)) {
+        return ['target_id' => reset($mid)];
+      }
+      // Create new media entity.
+      $newValues = [
+        'field_media_oembed_video' => $video_value,
+        'name' => $video_value,
+      ];
+      $embed = false;
+      $target_id =
+        EarthNewsImporterUtility::createNewMediaEntity('video', $newValues, $embed);
+      return ['target_id' => reset($target_id)];
+    }
+    else {
+      $xyz = 1; // some other media field
+    }
+    return null;
+  }
+
+}
+

--- a/src/Plugin/migrate/process/EarthBannerMedia.php
+++ b/src/Plugin/migrate/process/EarthBannerMedia.php
@@ -23,8 +23,15 @@ class EarthBannerMedia extends ProcessPluginBase {
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
 
-    if (!empty($value['field_p_hero_banner_media'])) {
-      $banner_media = reset($value['field_p_hero_banner_media']);
+    if (!empty($value['field_p_hero_banner_media']) ||
+      !empty($value['field_p_responsive_media'])) {
+      $banner_media = null;
+      if (!empty($value['field_p_hero_banner_media'])) {
+        $banner_media = reset($value['field_p_hero_banner_media']);
+      }
+      else if (!empty($value['field_p_responsive_media'])) {
+        $banner_media = reset($value['field_p_responsive_media']);
+      }
       if (!empty($banner_media['type']) && $banner_media['type'] === 'image'
         && !empty($banner_media['id'])) {
         $field_media = [];
@@ -35,7 +42,6 @@ class EarthBannerMedia extends ProcessPluginBase {
         return ['target_id' => $target_id];
       }
       else {
-        $xyz = 1; //banner media not image?
         return null;
       }
     }
@@ -58,9 +64,6 @@ class EarthBannerMedia extends ProcessPluginBase {
       $target_id =
         EarthNewsImporterUtility::createNewMediaEntity('video', $newValues, $embed);
       return ['target_id' => reset($target_id)];
-    }
-    else {
-      $xyz = 1; // some other media field
     }
     return null;
   }

--- a/src/Plugin/migrate/process/EarthBannerMediaCaption.php
+++ b/src/Plugin/migrate/process/EarthBannerMediaCaption.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\earth_news_importer\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\Core\Mail\MailFormatHelper;
+use Drupal\earth_news_importer\EarthNewsImporterUtility;
+
+/**
+ * Currently used only for the Top Media Banner Caption/Photo Credit.
+ * Input from Old Earth in which the underlying field might be one of
+ * several paragraph types. Strips out HTML and returns plain text limited
+ * to 255 characters.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "earth_banner_media_caption"
+ * )
+ *
+ */
+class EarthBannerMediaCaption extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $text = "";
+    if (!empty($value['field_p_responsive_image_cred'])) {
+      $text = reset($value['field_p_responsive_image_cred']);
+    }
+    else if (!empty($value['field_p_hero_banner_photo_credit'])) {
+      $text = reset($value['field_p_hero_banner_photo_credit']);
+    }
+    if (!empty($text)) {
+      $text = MailFormatHelper::htmlToText($text);
+      $text = htmlspecialchars($text);
+      $text = substr($text, 0, 255);
+      return $text;
+    }
+    return $value;
+   }
+
+}

--- a/src/Plugin/migrate/process/EarthBannerMediaCaption.php
+++ b/src/Plugin/migrate/process/EarthBannerMediaCaption.php
@@ -36,6 +36,7 @@ class EarthBannerMediaCaption extends ProcessPluginBase {
       $text = MailFormatHelper::htmlToText($text);
       $text = htmlspecialchars($text);
       $text = substr($text, 0, 255);
+      $text = preg_replace('/[^a-zA-Z0-9 \.\,]/','', $text);
       return $text;
     }
     return $value;

--- a/src/Plugin/migrate/process/EarthMediaImage.php
+++ b/src/Plugin/migrate/process/EarthMediaImage.php
@@ -82,6 +82,9 @@ class EarthMediaImage extends FileImport {
         if (!empty($value[$key])) {
           $property = $value[$key];
         }
+        if ($key === 'alt' && !empty($property) && strlen($property) > 512) {
+          $property = substr($property, 0, 512);
+        }
         if ($key == 'title' && empty($property)) {
           $property = $value['name'];
         }
@@ -120,11 +123,8 @@ class EarthMediaImage extends FileImport {
       ];
       $embed = !empty($this->configuration['embed']);
       return EarthNewsImporterUtility::createNewMediaEntity('video', $newValues, $embed);
-
-    // Otherwise, do nothing, but we have a breakpoint here in debugging to catch other media types.
-    } else {
-      $xyz = 1; // some other media
     }
+    return null;
   }
 
 }

--- a/src/Plugin/migrate/process/EarthMediaImage.php
+++ b/src/Plugin/migrate/process/EarthMediaImage.php
@@ -40,32 +40,40 @@ class EarthMediaImage extends FileImport {
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
 
-    if (empty($value['type'])) {
-      return NULL;
+    $embed = !empty($this->configuration['embed']);
+    $earth_id = "";
+    if ($embed && !empty($value['embed'])) {
+      $earth_id = $value['embed'];
+    }
+    else if (!empty($value['mid'])) {
+      $earth_id = strval($value['mid']);
+    }
+
+    if (empty($value['type']) || empty($earth_id)) {
+      return null;
     }
 
     // Are we importing an image?
     if ($value['type'] == 'image') {
       // Get the URL to the image or return null if empty
       if (empty($value['url']) || empty($value['name'])) {
-        return NULL;
+        return null;
       }
-
       // Check if we already have the image and return it if we do.
       $file_name = $value['name'];
-      $file_name = str_replace(" ", "%20", $file_name);
-      $file_info = pathinfo($value['url']);
+      $url = $value['url'];
+      $file_info = pathinfo($url);
       if (!empty($file_info['basename']) && $file_info['basename'] !== $file_name) {
         $file_name = $file_info['basename'];
       }
-      $mid = EarthNewsImporterUtility::lookupMediaByProperty('name', $file_name, $value);
+      $mid = EarthNewsImporterUtility::lookupMediaByProperty(
+        'name', $file_name, $embed);
       if (!empty($mid)) {
-        return $mid;
+        return [$earth_id => $mid];
       }
 
       // The parent will download the image (if necessary) and get its fid.
       $this->configuration['id_only'] = FALSE;
-      $url = $value['url']; //str_replace("earth.stanford.edu", "se3-stage.stanford.edu", $value['url']);
       $newvalue = parent::transform($url, $migrate_executable, $row,
         $destination_property);
       // Add the image field specific sub fields.
@@ -84,8 +92,10 @@ class EarthMediaImage extends FileImport {
 
       // Create new media entity.
       $newValues = ['field_media_image' => $newvalue];
-      $embed = !empty($this->configuration['embed']);
-      return EarthNewsImporterUtility::createNewMediaEntity('image', $newValues, $value, $embed);
+      $mid = EarthNewsImporterUtility::createNewMediaEntity('image', $newValues, $embed);
+      if (!empty($mid)) {
+        return [$earth_id => $mid];
+      }
     }
 
     // Otherwise are we importing video?
@@ -97,8 +107,8 @@ class EarthMediaImage extends FileImport {
 
       // Check if we already have the video and return its mid if we do.
       $video_value = $value['value'];
-      $mid = EarthNewsImporterUtility::lookupMediaByProperty('field_media_oembed_video.value',
-        $video_value, $value);
+      $mid = EarthNewsImporterUtility::lookupMediaByProperty(
+        'field_media_oembed_video.value', $video_value, $embed);
       if (!empty($mid)) {
         return $mid;
       }
@@ -109,7 +119,7 @@ class EarthMediaImage extends FileImport {
         'name' => $value['name'],
       ];
       $embed = !empty($this->configuration['embed']);
-      return EarthNewsImporterUtility::createNewMediaEntity('video', $newValues, $value, $embed);
+      return EarthNewsImporterUtility::createNewMediaEntity('video', $newValues, $embed);
 
     // Otherwise, do nothing, but we have a breakpoint here in debugging to catch other media types.
     } else {

--- a/src/Plugin/migrate/process/EarthNewsParagraphs.php
+++ b/src/Plugin/migrate/process/EarthNewsParagraphs.php
@@ -18,6 +18,44 @@ use Drupal\earth_news_importer\EarthNewsImporterUtility;
  */
 class EarthNewsParagraphs extends ProcessPluginBase {
 
+  private $field_media;
+  private $embedded_media;
+
+  protected function build_su_card($values = []) {
+    $paragraph_array = [
+      'type' => 'stanford_card',
+    ];
+    if (!empty($values['header'])) {
+      $paragraph_array['su_card_header'] = $values['header'];
+    }
+    if (!empty($values['super_header'])) {
+      $paragraph_array['su_card_super_header'] = $values['super_header'];
+    }
+    if (!empty($values['body'])) {
+      $paragraph_array['su_card_body'] = [
+        'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(
+          $values['body'], $this->embedded_media),
+        'format' => 'stanford_html',
+      ];
+    }
+    if (!empty($values['link'])) {
+      $paragraph_array['su_card_link'] = [
+        'uri' => $values['link']['uri'],
+        'title' => $values['link']['title'],
+        'options' => $values['link']['options'],
+      ];
+    }
+    if (!empty($values['media'])) {
+      if (!empty($values['media']['id'])) {
+        $paragraph_array['su_card_media'] = [
+          'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($values['media']['id'],
+            $this->field_media),
+        ];
+      }
+    }
+    return $paragraph_array;
+  }
+
   /**
    * {@inheritdoc}
    */
@@ -29,14 +67,14 @@ class EarthNewsParagraphs extends ProcessPluginBase {
     }
 
     // Get our imported media field array.
-    $field_media = [];
+    $this->field_media = [];
     if (!empty($this->configuration['field_media'])) {
-      $field_media = $row->getDestinationProperty($this->configuration['field_media']);
+      $this->field_media = $row->getDestinationProperty($this->configuration['field_media']);
     }
     // Get our imported embedded media array.
-    $embedded_media = [];
+    $this->embedded_media = [];
     if (!empty($this->configuration['embedded_media'])) {
-      $embedded_media = $row->getDestinationProperty($this->configuration['embedded_media']);
+      $this->embedded_media = $row->getDestinationProperty($this->configuration['embedded_media']);
     }
 
     // We will build a paragraph array to save and return to the migration API.
@@ -54,7 +92,7 @@ class EarthNewsParagraphs extends ProcessPluginBase {
           'type' => 'stanford_wysiwyg',
           'su_wysiwyg_text' => [
             'value' =>  EarthNewsImporterUtility::replaceEmbeddedMediaUuid(reset($value[$first_key]),
-              $embedded_media),
+              $this->embedded_media),
             'format' => 'stanford_html',
           ],
         ];
@@ -62,15 +100,13 @@ class EarthNewsParagraphs extends ProcessPluginBase {
 
       // import a SLAT paragraph
       else if (str_contains($first_key, 'field_p_slat')) {
-        $paragraph_array = [
-          'type' => 'stanford_card'
-        ];
+        $values = [];
         $body_text = '';
         if (!empty($value['field_p_slat_media'])) {
           $slat_media = reset($value['field_p_slat_media']);
           if (!empty($slat_media['id'])) {
             $slat_mid = EarthNewsImporterUtility::replaceFieldMediaId($slat_media['id'],
-              $field_media);
+              $this->field_media);
             $uuid = EarthNewsImporterUtility::getMediaUuid($slat_mid);
             $caption = "";
             if (!empty($value['field_p_slat_image_caption'])) {
@@ -96,51 +132,34 @@ class EarthNewsParagraphs extends ProcessPluginBase {
           }
         }
         if (!empty($value['field_p_slat_description'])) {
-          $body_text .= EarthNewsImporterUtility::replaceEmbeddedMediaUuid(reset($value['field_p_slat_description']),
-            $embedded_media);
+          $body_text .= reset($value['field_p_slat_description']);
         }
         if (!empty($body_text)) {
-          $paragraph_array['su_card_body'] = [
-              'value' => $body_text .
-                EarthNewsImporterUtility::replaceEmbeddedMediaUuid(reset($value['field_p_slat_description']),
-                  $embedded_media),
-              'format' => 'stanford_html',
-          ];
+          $values['body'] = $body_text;
         }
         $header = 'Required header field';
         if (!empty($value['field_p_slat_title'])) {
           $header = $value['field_p_slat_title'];
         }
-        $paragraph_array['su_card_header'] = $header;
+        $values['header'] = $header;
         if (!empty($value['field_p_slat_link'])) {
-          $paragraph_array['su_card_link'] = [
-            'uri' => $value['field_p_slat_link']['uri'],
-            'title' => $value['field_p_slat_link']['title'],
-            'options' => $value['field_p_slat_link']['options'],
-          ];
+          $values['link'] = $value['field_p_slat_link'];
         }
+        $paragraph_array = $this->build_su_card($values);
       }
 
       // import a Pull Quote paragraph
       else if (strpos($first_key, 'field_p_quote') !== false) {
-        $paragraph_array = [
-          'type' => 'stanford_card'
-        ];
+        $values = [];
         if (!empty($value['field_p_quote_bg_img_media'])) {
-          $pquote_media = reset($value['field_p_quote_bg_img_media']);
-          if (!empty($pquote_media['id'])) {
-            $paragraph_array['su_card_media'] = [
-              'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($pquote_media['id'],
-                $field_media),
-            ];
-          }
+          $values['media'] = reset($value['field_p_quote_bg_img_media']);
         }
         $quote_body = '';
         if (!empty($value['field_p_quote_person_img_media'])) {
-          $pquote_person = reset($value['field_p_quote_person_img_media']);
+          $pquote_image = reset($value['field_p_quote_person_img_media']);
           if (!empty($pquote_person['id'])) {
             $person_mid = EarthNewsImporterUtility::replaceFieldMediaId($pquote_person['id'],
-              $field_media);
+              $this->field_media);
             $uuid = EarthNewsImporterUtility::getMediaUuid($person_mid);
             $quote_body .= "<drupal-media data-align=\"left\" data-entity-type=\"media\" ";
             $quote_body .= "data-entity-uuid=\"" . $uuid . "\" ";
@@ -157,34 +176,17 @@ class EarthNewsParagraphs extends ProcessPluginBase {
           $quote_body .= ",&nbsp;" . reset($value['field_p_quote_title']);
         }
         if (!empty($quote_body)) {
-          $paragraph_array['su_card_body'] = [
-            'value' => $quote_body,
-            'format' => 'stanford_html',
-          ];
+          $values['body'] = $quote_body;
         }
-        $paragraph_array['su_card_header'] = "Required card header";
+        $values['header'] = "Required card header";
+        $paragraph_array = $this->build_su_card($values);
       }
 
       // import a Postcard paragraph.
       else if (str_contains($first_key, 'field_p_postcard')) {
-        $paragraph_array = [
-          'type' => 'stanford_card'
-        ];
+        $values = [];
         if (!empty($value['field_p_postcard_body'])) {
-          $paragraph_array['su_card_body'] = [
-            'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(reset($value['field_p_postcard_body']),
-              $embedded_media),
-            'format' => 'stanford_html',
-          ];
-        }
-        if (!empty($value['field_p_postcard_media'])) {
-          $postcard_media = reset($value['field_p_postcard_media']);
-          if (!empty($postcard_media['id'])) {
-            $paragraph_array['su_card_media'] = [
-              'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($postcard_media['id'],
-                $field_media),
-            ];
-          }
+          $values['body'] = reset($value['field_p_postcard_body']);
         }
         $header = "Required card header";
         if (!empty($value['field_p_postcard_title'])) {
@@ -192,14 +194,11 @@ class EarthNewsParagraphs extends ProcessPluginBase {
             reset($value['field_p_postcard_title']),
           ];
         }
-        $paragraph_array['su_card_header'] = $header;
+        $values['header'] = $header;
         if (!empty($value['field_p_postcard_more'])) {
-          $paragraph_array['su_card_link'] = [
-            'uri' => $value['field_p_postcard_more']['uri'],
-            'title' => $value['field_p_postcard_more']['title'],
-            'options' => $value['field_p_postcard_more']['options'],
-          ];
+          $values['link'] = $value['field_p_postcard_more'];
         }
+        $paragraph_array = $this->build_su_card($values);
       }
 
       // import a stanford media caption paragraph
@@ -251,35 +250,23 @@ class EarthNewsParagraphs extends ProcessPluginBase {
       else if (str_contains($first_key, 'field_p_banner')) {
         if ($first_key === 'field_p_banner_cards') {
           if (!empty($value['field_p_banner_cards'])) {
-            foreach ($value['field_p_banner_cards'] as $banner_card) {
-              if (!empty($banner_card)) {
-                $paragraph_array = [
-                  'type' => 'stanford_card',
-                ];
-                if (!empty($banner_card['field_highlight_card_title'])) {
-                  $paragraph_array['su_card_header'] =
-                    reset($banner_card['field_p_highlight_card_title']);
-                }
-                if (!empty($banner_card['field_p_highlight_card_subtitle'])) {
-                  $paragraph_array['su_card_super_header'] =
-                    reset($banner_card['field_p_highlight_card_subtitle']);
-                }
-                if (!empty($banner_card['field_p_highlight_card_desc'])) {
-                  $paragraph_array['su_card_body'] = [
-                    'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(reset($banner_card['field_p_highlight_card_desc']),
-                      $embedded_media),
-                    'format' => 'stanford_html',
-                  ];
-                }
-                if (!empty($banner_card['field_p_highlight_card_link'])) {
-                  $paragraph_array['su_card_link'] = [
-                      'uri' => $banner_card['field_p_highlight_card_link']['uri'],
-                      'title' => $banner_card['field_p_highlight_card_link']['title'],
-                      'options' => $banner_card['field_p_highlight_card_link']['options'],
-                    ];
-                }
-              }
+            $banner_card = reset($value['field_p_banner_cards']);
+            $values = [];
+            if (!empty($banner_card['field_highlight_card_title'])) {
+              $values['header'] =
+                reset($banner_card['field_p_highlight_card_title']);
             }
+            if (!empty($banner_card['field_p_highlight_card_subtitle'])) {
+              $values['super_header'] =
+                reset($banner_card['field_p_highlight_card_subtitle']);
+            }
+            if (!empty($banner_card['field_p_highlight_card_desc'])) {
+              $values['body'] = reset($banner_card['field_p_highlight_card_desc']);
+            }
+            if (!empty($banner_card['field_p_highlight_card_link'])) {
+              $values['link'] = $banner_card['field_p_highlight_card_link'];
+            }
+            $paragraph_array = $this->build_su_card($values);
           }
         }
        else {
@@ -291,7 +278,7 @@ class EarthNewsParagraphs extends ProcessPluginBase {
             if (!empty($banner_media['id'])) {
               $paragraph_array['su_banner_image'] = [
                 'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($banner_media['id'],
-                  $field_media),
+                  $this->field_media),
               ];
             }
           }
@@ -305,41 +292,24 @@ class EarthNewsParagraphs extends ProcessPluginBase {
       else if (str_contains($first_key, 'field_p_feat_blocks')) {
         if ($first_key === 'field_p_feat_blocks_block') {
           if (!empty($value['field_p_feat_blocks_block'])) {
-            foreach ($value['field_p_feat_blocks_block'] as $banner_card) {
-              if (!empty($banner_card)) {
-                $paragraph_array = [
-                  'type' => 'stanford_card',
-                ];
-                if (!empty($banner_card['field_p_simple_block_title'])) {
-                  $paragraph_array['su_card_header'] =
-                    reset($banner_card['field_p_simple_block_title']);
-                }
-                if (!empty($banner_card['field_p_simple_block_description'])) {
-                  $paragraph_array['su_card_body'] = [
-                    'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(reset($banner_card['field_p_simple_block_description']),
-                      $embedded_media),
-                    'format' => 'stanford_html',
-                  ];
-                }
-                if (!empty($banner_card['field_p_simple_block_link'])) {
-                  $paragraph_array['su_card_link'] = [
-                    'uri' => $banner_card['field_p_simple_block_link']['uri'],
-                    'title' => $banner_card['field_p_simple_block_link']['title'],
-                    'options' => $banner_card['field_p_simple_block_link']['options'],
-                  ];
-                }
-                if (!empty($banner_card['field_p_simple_block_media'])) {
-                  $card_media = reset($banner_card['field_p_simple_block_media']);
-                  if (!empty($card_media['id'])) {
-                    $paragraph_array['su_card_media'] = [
-                      'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($card_media['id'],
-                        $field_media),
-                    ];
-                  }
-                }
-
-              }
+            $banner_card = reset($value['field_p_feat_blocks_block']);
+            $values= [];
+            if (!empty($banner_card['field_p_simple_block_title'])) {
+              $values['header'] =
+                reset($banner_card['field_p_simple_block_title']);
             }
+            if (!empty($banner_card['field_p_simple_block_description'])) {
+              $values['body'] =
+                reset($banner_card['field_p_simple_block_description']);
+            }
+            if (!empty($banner_card['field_p_simple_block_link'])) {
+              $values['link'] = $banner_card['field_p_simple_block_link'];
+            }
+            if (!empty($banner_card['field_p_simple_block_media'])) {
+              $values['media'] =
+                reset($banner_card['field_p_simple_block_media']);
+            }
+            $paragraph_array = $this->build_su_card($values);
           }
         }
         else {
@@ -377,7 +347,7 @@ class EarthNewsParagraphs extends ProcessPluginBase {
           $paragraph_array['su_media_caption_caption'] = [
             'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(
               reset($value['field_p_responsive_image_cred']),
-              $embedded_media
+              $this->embedded_media
             ),
             'format' => 'stanford_html',
           ];
@@ -387,7 +357,7 @@ class EarthNewsParagraphs extends ProcessPluginBase {
           if (!empty($responsive_media['id'])) {
             $paragraph_array['su_media_caption_media'] = [
               'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($responsive_media['id'],
-                $field_media),
+                $this->field_media),
             ];
           }
         }
@@ -395,97 +365,78 @@ class EarthNewsParagraphs extends ProcessPluginBase {
 
       // callout card
       else if (str_contains($first_key, 'field_p_callout')) {
-        $paragraph_array = [
-          'type' => 'stanford_card',
-        ];
+        $values = [];
         if (!empty($value['field_p_callout_wysiwyg'])) {
-          $paragraph_array['su_card_body'] = [
-            'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(
-              reset($value['field_p_callout_wysiwyg']),
-              $embedded_media
-            ),
-            'format' => 'stanford_html',
-          ];
+          $values['body'] = reset($value['field_p_callout_wysiwyg']);
         }
         if (!empty($value['field_p_callout_more_link'])) {
-          $paragraph_array['su_card_link'] = [
-            'uri' => $value['field_p_callout_more_link']['uri'],
-            'title' => $value['field_p_callout_more_link']['title'],
-            'options' => $value['field_p_callout_more_link']['options'],
-          ];
+          $values['link'] = $value['field_p_callout_more_link'];
         }
         if (!empty($value['field_p_callout_title'])) {
-          $paragraph_array['su_card_header'] =
-            reset($value['field_p_callout_title']);
+          $values['header'] = $value['field_p_callout_title'];
         }
+        $paragraph_array = $this->build_su_card($values);
       }
 
       // filmstrip slide
       else if (str_contains($first_key, 'field_p_filmstrip')) {
-        $paragraph_array = [
-          'type' => 'stanford_card',
-        ];
-        if (!empty($value['field_p_callout_wysiwyg'])) {
-          $paragraph_array['su_card_body'] = [
-            'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(
-              reset($value['field_p_callout_wysiwyg']),
-              $embedded_media
-            ),
+        if ($first_key === "field_p_filmstrip_title") {
+          $paragraph_array = [
+            'type' => 'stanford_wysiwyg',
+            'value' => '<h3>' .
+              reset($value['field_p_filmstrip_title']) . '</h3>',
             'format' => 'stanford_html',
           ];
         }
-        if (!empty($value['field_p_callout_more_link'])) {
-          $paragraph_array['su_card_link'] = [
-            'uri' => $value['field_p_callout_more_link']['uri'],
-            'title' => $value['field_p_callout_more_link']['title'],
-            'options' => $value['field_p_callout_more_link']['options'],
-          ];
+        else if ($first_key === 'field_p_filmstrip_slide') {
+          $slide = reset($value['field_p_filmstrip_slide']);
+          $values = [];
+          if (!empty($slide['field_p_slide_body'])) {
+            $values['body'] = reset($slide['field_p_slide_body']);
+          }
+          if (!empty($slide['field_p_slide_link'])) {
+            $values['link'] = $slide['field_p_slide_link'];
+          }
+          if (!empty($slide['field_p_slide_media'])) {
+            $values['media'] =
+              reset($slide['field_p_slide_media']);
+          }
+          $paragraph_array = $this->build_su_card($values);
         }
-        if (!empty($value['field_p_callout_title'])) {
-          $paragraph_array['su_card_header'] =
-            reset($value['field_p_callout_title']);
+        else {
+          $values = [];
+          if (!empty($value['field_p_slide_body'])) {
+            $values['body'] = reset($value['field_p_slide_body']);
+          }
+          if (!empty($value['field_p_slide_link'])) {
+            $values['link'] = $value['field_p_callout_more_link'];
+          }
+          if (!empty($value['field_p_slide_media'])) {
+            $values['media'] =
+              reset($value['field_p_slide_media']);
+          }
+          $paragraph_array = $this->build_su_card($values);
         }
       }
 
       // import double film strip
       else if (str_contains($first_key, 'field_p_doub')) {
-        if ($first_key === 'field_p_double_film_cards') {
-          if (!empty($value['field_p_double_film_cards'])) {
-            foreach ($value['field_p_double_film_cards'] as $banner_card) {
-              if (!empty($banner_card)) {
-                $paragraph_array = [
-                  'type' => 'stanford_card',
-                ];
-                if (!empty($banner_card['field_s_film_card_title'])) {
-                  $paragraph_array['su_card_header'] =
-                    reset($banner_card['field_s_film_card_title']);
-                }
-                if (!empty($banner_card['field_s_film_card_desc'])) {
-                  $paragraph_array['su_card_body'] = [
-                    'value' => EarthNewsImporterUtility::replaceEmbeddedMediaUuid(reset($banner_card['field_s_film_card_desc']),
-                      $embedded_media),
-                    'format' => 'stanford_html',
-                  ];
-                }
-                if (!empty($banner_card['field_s_film_card_link'])) {
-                  $paragraph_array['su_card_link'] = [
-                    'uri' => $banner_card['field_s_film_card_link']['uri'],
-                    'title' => $banner_card['field_s_film_card_link']['title'],
-                    'options' => $banner_card['field_s_film_card_link']['options'],
-                  ];
-                }
-                if (!empty($banner_card['field_s_film_card_media'])) {
-                  $responsive_media = reset($banner_card['field_s_film_card_media']);
-                  if (!empty($responsive_media['id'])) {
-                    $paragraph_array['su_card_media'] = [
-                      'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($responsive_media['id'],
-                        $field_media),
-                    ];
-                  }
-                }
-              }
-            }
+        if ($first_key === 'field_p_doub_film_cards') {
+          $banner_card = reset($value['field_p_doub_film_cards']);
+          $values = [];
+          if (!empty($banner_card['field_s_film_card_title'])) {
+            $values['header'] = reset($banner_card['field_s_film_card_title']);
           }
+          if (!empty($banner_card['field_s_film_card_desc'])) {
+            $values['body'] = reset($banner_card['field_s_film_card_desc']);
+          }
+          if (!empty($banner_card['field_s_film_card_link'])) {
+            $values['link'] = $banner_card['field_s_film_card_link'];
+          }
+          if (!empty($banner_card['field_s_film_card_media'])) {
+            $values['media'] = reset($banner_card['field_s_film_card_media']);
+          }
+          $paragraph_array = $this->build_su_card($values);
         }
         else {
           if (!empty($value['field_p_doub_film_title'][0])) {
@@ -504,28 +455,20 @@ class EarthNewsParagraphs extends ProcessPluginBase {
       else if (str_contains($first_key, 'field_p_link_banner')) {
         if ($first_key === 'field_p_link_banner_links') {
           if (!empty($value['field_p_link_banner_links'])) {
-            foreach ($value['field_p_link_banner_links'] as $banner_card) {
-              if (!empty($banner_card)) {
-                $paragraph_array = [
-                  'type' => 'stanford_card',
-                ];
-                if (!empty($banner_card['field_p_link_item_subtext'])) {
-                  $paragraph_array['su_card_header'] =
+            $banner_card = reset($value('field_p_link_banner_links'));
+            $values = [];
+            if (!empty($banner_card['field_p_link_item_subtext'])) {
+                  $values['header'] =
                     reset($banner_card['field_p_link_item_subtext']);
-                }
-                if (!empty($banner_card['field_p_link_item_text'])) {
-                  $paragraph_array['su_card_super_header'] =
-                    reset($banner_card['field_p_link_item_text']);
-                }
-                if (!empty($banner_card['field_p_link_item_url'])) {
-                  $paragraph_array['su_card_link'] = [
-                    'uri' => $banner_card['field_p_link_item_url']['uri'],
-                    'title' => $banner_card['field_p_link_item_url']['title'],
-                    'options' => $banner_card['field_p_link_item_url']['options'],
-                  ];
-                }
-              }
             }
+            if (!empty($banner_card['field_p_link_item_text'])) {
+                  $values['super_header'] =
+                    reset($banner_card['field_p_link_item_text']);
+            }
+            if (!empty($banner_card['field_p_link_item_url'])) {
+              $values['link'] = $banner_card['field_p_link_item_url'];
+            }
+            $paragraph_array = $this->build_su_card($values);
           }
         }
         else {
@@ -537,7 +480,7 @@ class EarthNewsParagraphs extends ProcessPluginBase {
             if (!empty($banner_media['id'])) {
               $paragraph_array['su_banner_image'] = [
                 'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($banner_media['id'],
-                  $field_media),
+                  $this->field_media),
               ];
             }
           }
@@ -556,45 +499,27 @@ class EarthNewsParagraphs extends ProcessPluginBase {
       // tall filmstrip
       else if (str_contains($first_key, 'field_p_tall_filmstrip')) {
         if ($first_key === 'field_p_tall_filmstrip_cards') {
-          if (!empty($value['field_p_tall_filmstrip_cards'])) {
-            foreach ($value['field_p_tall_filmstrip_cards'] as $banner_card) {
-              if (!empty($banner_card)) {
-                $paragraph_array = [
-                  'type' => 'stanford_card',
-                ];
-                if (!empty($value['field_p_tall_slide_desc'])) {
-                  $paragraph_array['su_card_body'] = [
-                    'value' => reset($value['field_p_tall_slide_desc']),
-                    'format' => 'stanford_html',
-                  ];
-                }
-                if (!empty($banner_card['field_p_tall_slide_title'])) {
-                  $paragraph_array['su_card_header'] =
-                    reset($banner_card['field_p_tall_slide_title']);
-                }
-                if (!empty($banner_card['field_p_tall_slide_subtitle'])) {
-                  $paragraph_array['su_card_super_header'] =
-                    reset($banner_card['field_p_tall_slide_subtitle']);
-                }
-                if (!empty($banner_card['field_p_tall_slide_link'])) {
-                  $paragraph_array['su_card_link'] = [
-                    'uri' => $banner_card['field_p_tall_slide_link_url']['uri'],
-                    'title' => $banner_card['field_p_tall_slide_link_url']['title'],
-                    'options' => $banner_card['field_p_tall_slide_link_url']['options'],
-                  ];
-                }
-                if (!empty($banner_card['field_p_tall_slide_media'])) {
-                  $responsive_media = reset($banner_card['field_p_tall_slide_media']);
-                  if (!empty($responsive_media['id'])) {
-                    $paragraph_array['su_card_media'] = [
-                      'target_id' => EarthNewsImporterUtility::replaceFieldMediaId($responsive_media['id'],
-                        $field_media),
-                    ];
-                  }
-                }
-              }
-            }
+          $banner_card = reset($value['field_p_tall_filmstrip_cards']);
+          $values = [];
+          if (!empty($value['field_p_tall_slide_desc'])) {
+            $values['body'] = reset($value['field_p_tall_slide_desc']);
           }
+          if (!empty($banner_card['field_p_tall_slide_title'])) {
+            $values['header'] =
+              reset($banner_card['field_p_tall_slide_title']);
+          }
+          if (!empty($banner_card['field_p_tall_slide_subtitle'])) {
+            $values['super_header'] =
+              reset($banner_card['field_p_tall_slide_subtitle']);
+          }
+          if (!empty($banner_card['field_p_tall_slide_link'])) {
+            $values['link'] = $banner_card['field_p_tall_slide_link'];
+          }
+          if (!empty($banner_card['field_p_tall_slide_media'])) {
+            $values['media'] =
+              reset($banner_card['field_p_tall_slide_media']);
+          }
+          $paragraph_array = $this->build_su_card($values);
         }
         else {
           $tall_text = "<div>";
@@ -617,26 +542,19 @@ class EarthNewsParagraphs extends ProcessPluginBase {
 
       // link item paragraph
       else if (str_contains($first_key, 'field_p_link_item')) {
-        $paragraph_array = [
-          'type' => 'stanford_card',
-        ];
+        $values = [];
         if (!empty($value['field_p_link_item_text'])) {
-          $paragraph_array['su_card_header'] =
-            reset($value['field_p_link_item_text']);
+          $values['header'] = reset($value['field_p_link_item_text']);
         }
         if (!empty($value['field_p_link_item_url'])) {
-          $paragraph_array['su_card_link'] = [
-            'uri' => $value['field_p_link_item_url']['uri'],
-            'title' => $value['field_p_link_item_url']['title'],
-            'options' => $value['field_p_link_item_url']['options'],
-          ];
+          $values['link'] = value['field_p_link_item_url'];
         }
-
+        $paragraph_array = $this->build_su_card($values);
       }
 
-        // catch any unprocessed paragraphs here - used for debugging.
+      // catch any unprocessed paragraphs here - used for debugging.
       else {
-        $xyz = 1;
+        \Drupal::messenger()->addStatus("Unable to import paragraph whose first key is: " . $first_key . "\.");
       }
 
       // If we have a new paragraph array, save it and return its id.

--- a/src/Plugin/migrate/process/EarthNewsParagraphs.php
+++ b/src/Plugin/migrate/process/EarthNewsParagraphs.php
@@ -198,6 +198,10 @@ class EarthNewsParagraphs extends ProcessPluginBase {
         if (!empty($value['field_p_postcard_more'])) {
           $values['link'] = $value['field_p_postcard_more'];
         }
+        if (!empty($value['field_p_postcard_media'])) {
+          $values['media'] = reset($value['field_p_postcard_media']);
+        }
+
         $paragraph_array = $this->build_su_card($values);
       }
 
@@ -455,7 +459,7 @@ class EarthNewsParagraphs extends ProcessPluginBase {
       else if (str_contains($first_key, 'field_p_link_banner')) {
         if ($first_key === 'field_p_link_banner_links') {
           if (!empty($value['field_p_link_banner_links'])) {
-            $banner_card = reset($value('field_p_link_banner_links'));
+            $banner_card = reset($value['field_p_link_banner_links']);
             $values = [];
             if (!empty($banner_card['field_p_link_item_subtext'])) {
                   $values['header'] =
@@ -547,7 +551,7 @@ class EarthNewsParagraphs extends ProcessPluginBase {
           $values['header'] = reset($value['field_p_link_item_text']);
         }
         if (!empty($value['field_p_link_item_url'])) {
-          $values['link'] = value['field_p_link_item_url'];
+          $values['link'] = $value['field_p_link_item_url'];
         }
         $paragraph_array = $this->build_su_card($values);
       }

--- a/src/Plugin/migrate/process/EarthRelatedPeople.php
+++ b/src/Plugin/migrate/process/EarthRelatedPeople.php
@@ -27,9 +27,6 @@ class EarthRelatedPeople extends ProcessPluginBase {
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
     if (!empty($value) && is_array($value)) {
       $return_array = [];
-      if (count($value) > 1) {
-        $xyz = 1;
-      }
       foreach ($value as $person) {
         if (!empty($person['display_name'])) {
           $display_name = $person['display_name'];

--- a/src/Plugin/migrate/process/EarthRelatedPeople.php
+++ b/src/Plugin/migrate/process/EarthRelatedPeople.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\earth_news_importer\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\earth_news_importer\EarthNewsImporterUtility;
+
+/**
+ * Tries to find the stanford_person entity matching the related persons
+ * on the Old Earth news related_people field. Does lookup by display_name
+ * even though Old Earth provides SUNet ID. Currently does not generate
+ * a person if not found.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "earth_related_people",
+ *   handle_multiples = true
+ * )
+ *
+ */
+class EarthRelatedPeople extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if (!empty($value) && is_array($value)) {
+      $return_array = [];
+      if (count($value) > 1) {
+        $xyz = 1;
+      }
+      foreach ($value as $person) {
+        if (!empty($person['display_name'])) {
+          $display_name = $person['display_name'];
+          $nids = \Drupal::entityTypeManager()->getStorage('node')
+            ->loadByProperties(['title' => $display_name, 'type' => 'stanford_person']);
+          $found = array_key_first($nids);
+          if (!empty($found)) {
+            $return_array[] = ['target_id' => strval($found)];
+          }
+        }
+      }
+      return $return_array;
+    }
+    return null;
+  }
+
+}
+

--- a/tests/src/Unit/EarthNewsImporterTest.php
+++ b/tests/src/Unit/EarthNewsImporterTest.php
@@ -1,0 +1,15 @@
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Tests presence of this module.
+ *
+ * @group earth_news_importer
+ */
+class EarthNewsImporterTest extends UnitTestCase {
+
+  public function testModuleExists() {
+    $this->assertTrue(\Drupal::moduleHandler()->moduleExists('earth_news_importer'));
+  }
+
+}
+


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Latest version of earth_news_importer 

Updates migration configurations for 2022 and 2023 and adds configurations for 2013-2021.
- Adds new fields for import source url and related people.
- Fixes banner field import
- Makes imported news pages unpublished.

Updates and Refactors Paragraph process plugin
- Adds processing of paragraph types from earth missing in last version.
- Code clean up.

New plugins
- Banner Media
- Banner Media Caption - strips HTML and limits plain text to 255 characters
- Related People lookup

- Other code cleanup

# Review By (Date)
- As soon as possible

# Criticality
- Soon

# Review Tasks

## Setup tasks and/or behavior to test

- Let me know when merged so I can test on stage or dev

## General

# Affected Projects or Products
-SDSS Newsroom

# Associated Issues and/or People
- SDSS-349

