### PR TITLE
SDSS-732: Import into new banner caption field etc

### DIFF
--- a/config/install/migrate_plus.migration.earth_news_importer_2013.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2013.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2014.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2014.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2015.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2015.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2016.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2016.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2017.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2017.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2018.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2018.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2019.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2019.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2020.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2020.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2021.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2021.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2022.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2022.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/config/install/migrate_plus.migration.earth_news_importer_2023.yml
+++ b/config/install/migrate_plus.migration.earth_news_importer_2023.yml
@@ -260,6 +260,20 @@ process:
   su_news_banner_media_caption:
     plugin: earth_banner_media_caption
     source: banner_media
+    plaintext: true
+  long_caption:
+    plugin: earth_banner_media_caption
+    method: process
+    source: null
+    banner_media: banner_media/0
+    plaintext: false
+  su_sdss_news_banner_caption/value:
+    plugin: earth_embedded_media_body
+    method: process
+    source: null
+    dek: long_caption
+    embedded_media: embedded_media
+  su_sdss_news_banner_caption/format: constants/stanford_minimal_html
   su_news_source: news_source
   su_sdss_import_source:
     plugin: concat
@@ -271,4 +285,6 @@ process:
     source: related_people
 destination:
   plugin: 'entity:node'
+  overwrite_properties:
+    - fake-field-to-make-others-read-write
 migration_dependencies: {  }

--- a/earth_news_importer.install
+++ b/earth_news_importer.install
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * earth_news_importer.install
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function earth_news_importer_uninstall() {
+  // Delete the news migration configurations.
+  $configFactory = \Drupal::configFactory();
+  $migrations = $configFactory->listAll('migrate_plus.migration.earth_news_importer');
+  foreach ($migrations as $migration) {
+    $configFactory->getEditable($migration)->delete();
+  }
+  // Delete the configuration group.
+  $configFactory->getEditable('migrate_plus.migration_group.earth_news_importer')->delete();
+
+  $db = \Drupal::database();
+  // Delete the old migration map and message tables.
+  $tables = array_merge($db->schema()
+    ->findTables('migrate_map_earth_news_importer%'),
+    $db->schema()->findTables('migrate_message_earth_news_importer%'));
+  foreach ($tables as $table) {
+    $db->schema()->dropTable($table);
+  }
+
+}

--- a/src/Plugin/migrate/process/EarthBannerMediaCaption.php
+++ b/src/Plugin/migrate/process/EarthBannerMediaCaption.php
@@ -26,6 +26,11 @@ class EarthBannerMediaCaption extends ProcessPluginBase {
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
     $text = "";
+    if (empty($value)) {
+      if (!empty($this->configuration['banner_media'])) {
+        $value = reset($row->getSourceProperty($this->configuration['banner_media']));
+      }
+    }
     if (!empty($value['field_p_responsive_image_cred'])) {
       $text = reset($value['field_p_responsive_image_cred']);
     }
@@ -33,11 +38,15 @@ class EarthBannerMediaCaption extends ProcessPluginBase {
       $text = reset($value['field_p_hero_banner_photo_credit']);
     }
     if (!empty($text)) {
-      $text = MailFormatHelper::htmlToText($text);
-      $text = htmlspecialchars($text);
-      $text = substr($text, 0, 255);
-      $text = preg_replace('/[^a-zA-Z0-9 \.\,]/','', $text);
-      return $text;
+      if ($this->configuration['plaintext']) {
+        $text = MailFormatHelper::htmlToText($text);
+        $text = htmlspecialchars($text);
+        $text = substr($text, 0, 255);
+        $value = preg_replace('/[^a-zA-Z0-9 \.\,]/', '', $text);
+      }
+      else {
+        $value = $text;
+      }
     }
     return $value;
    }

--- a/src/Plugin/migrate/process/EarthBannerMediaCaption.php
+++ b/src/Plugin/migrate/process/EarthBannerMediaCaption.php
@@ -28,7 +28,7 @@ class EarthBannerMediaCaption extends ProcessPluginBase {
     $text = "";
     if (empty($value)) {
       if (!empty($this->configuration['banner_media'])) {
-        $value = reset($row->getSourceProperty($this->configuration['banner_media']));
+        $value = $row->getSourceProperty($this->configuration['banner_media']);
       }
     }
     if (!empty($value['field_p_responsive_image_cred'])) {
@@ -37,18 +37,13 @@ class EarthBannerMediaCaption extends ProcessPluginBase {
     else if (!empty($value['field_p_hero_banner_photo_credit'])) {
       $text = reset($value['field_p_hero_banner_photo_credit']);
     }
-    if (!empty($text)) {
-      if ($this->configuration['plaintext']) {
-        $text = MailFormatHelper::htmlToText($text);
-        $text = htmlspecialchars($text);
-        $text = substr($text, 0, 255);
-        $value = preg_replace('/[^a-zA-Z0-9 \.\,]/', '', $text);
-      }
-      else {
-        $value = $text;
-      }
+    if (!empty($text) && $this->configuration['plaintext']) {
+      $text = MailFormatHelper::htmlToText($text);
+      $text = htmlspecialchars($text);
+      $text = substr($text, 0, 255);
+      $text = preg_replace('/[^a-zA-Z0-9 \.\,]/', '', $text);
     }
-    return $value;
+    return $text;
    }
 
 }

--- a/src/Plugin/migrate/process/EarthNewsParagraphs.php
+++ b/src/Plugin/migrate/process/EarthNewsParagraphs.php
@@ -328,18 +328,21 @@ class EarthNewsParagraphs extends ProcessPluginBase {
 
       // import section header
       else if (str_contains($first_key, 'field_p_section_header')) {
-        $paragraph_array = [
-          'type' => 'stanford_banner',
-        ];
+        $section_text = "";
         if (!empty($value['field_p_section_header_title'])) {
-          $paragraph_array['su_banner_header'] = reset($value['field_p_section_header_title']);
+          $section_text .= "<h3>" . reset($value['field_p_section_header_title']) . '</h3>';
+          //$paragraph_array['su_banner_header'] = reset($value['field_p_section_header_title']);
         }
         if (!empty($value['field_p_section_header_desc'])) {
-          $paragraph_array['su_banner_body'] = [
-            'value' => reset($value['field_p_section_header_desc']),
-            'format' => 'stanford_html',
-          ];
+          $section_text .= reset($value['field_p_section_header_desc']);
         }
+        $paragraph_array = [
+          'type' => 'stanford_wysiwyg',
+          'su_wysiwyg_text' => [
+            'value' =>  $section_text,
+            'format' => 'stanford_html',
+          ]
+        ];
       }
 
       // responsive image
@@ -387,9 +390,11 @@ class EarthNewsParagraphs extends ProcessPluginBase {
         if ($first_key === "field_p_filmstrip_title") {
           $paragraph_array = [
             'type' => 'stanford_wysiwyg',
-            'value' => '<h3>' .
-              reset($value['field_p_filmstrip_title']) . '</h3>',
-            'format' => 'stanford_html',
+            'su_wysiwyg_text' => [
+              'value' => '<h3>' .
+                reset($value['field_p_filmstrip_title']) . '</h3>',
+              'format' => 'stanford_html',
+            ],
           ];
         }
         else if ($first_key === 'field_p_filmstrip_slide') {


### PR DESCRIPTION
Updates to earth_news_importer
- imports section_header paragraphs from earth into stanford_wysiwyg paragraphs instead of stanford_banner
- Fixes stanford_wysiwyg output for stanford_p_filmstrip paragraphs from earth
- Updates migration configurations to import banner captions into new wysiwyg field as well as original plaintext field
- Updates migration configurations to leave imported news nodes editable
- Adds an uninstall hook to delete news migration configurations, map, and message tables on module uninstall